### PR TITLE
[RELEASE] GLOB-51 First prod release for Permutive tvOS SDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Permutive_tvOS",
+    platforms: [.tvOS(.v11)],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Permutive_tvOS",
+            targets: ["Permutive_tvOS"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+    ],
+    targets: [
+        .binaryTarget(name:"Permutive_tvOS",
+                      url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive-tvOS-v1.0.0.zip",
+                      checksum: "d592a7aac9a4ae03615780bb1b2cf5e5c342eb3fa74b911a5e75408318bc4207")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Permutive tvOS SDK Swift Package
+
+This repo provides SPM support for Permutive tvOS SDK.
+
+You can find iOS support [here](https://github.com/permutive/permutive-ios-spm).
+
+Please refer to the SDK documentation [here](https://developer.permutive.com/docs/ios).
+Get the latest release notes [here](https://developer.permutive.com/docs/ios-release-notes).
+
+# Use Cocoapods?
+
+Easily include Permutive SDK in your Podfile:
+
+```
+target 'Your Target' do
+    platform :ios, '11.0'
+    pod 'Permutive_tvOS', '~> 1.0.0'
+end
+```


### PR DESCRIPTION
# 📰 Release v1.0.0 production release

# 📚 Description
This add support for Swift Package Manager to the tvOS Permutive SDK.

You can find Permutive SDK documentation [here](https://developer.permutive.com/docs/ios-sdk).
If you have implemented the beta SDK before, you can find the documentation to safely migrate to production release [here](https://developer.permutive.com/docs/moving-from-the-beta-sdk).

# 🎯 Link to JIRA issue(s)
[JIRA](https://permutive.atlassian.net/browse/GLOB-51)

# 💣 Type of change
- [x] Release

# 🧪 How has this been tested?
- [x] Integration tests
- [x] Unit tests

# 🔮 Future work
N/A