### PR TITLE
Release v2.5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name:"Permutive_tvOS",
-		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v2.5.1.zip",
-		checksum:"fb1e0291d57b700c909dd947a818d9cc7985fbfd689ff7a8995a245eb56eaa69")
+		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v2.5.2.zip",
+		checksum:"c8c8996a07da61f1772ddd77386ccc0afcb007031a730977e7d267a8677b788f")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Easily include Permutive SDK in your Podfile:
 ```
 target 'Your Target' do
     platform :tvos, '12.0'
-    pod 'Permutive_tvOS', '~> 2.5.1'
+    pod 'Permutive_tvOS', '~> 2.5.2'
 end
 ```


### PR DESCRIPTION
- Defaults to the Core Engine when no A/B test configuration applies (Fix)
- Persists Core Engine state in file storage instead of UserDefaults to fit within the tvOS UserDefaults size limit (Fix)