### PR TITLE
Release 3.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name:"Permutive_tvOS",
-		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v2.6.1.zip",
-		checksum:"0abe4174c9e31f48964daa859d4c202e364055a6ae386cebba1bd120041e7887")
+		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v3.0.0.zip",
+		checksum:"460ce792f6c3b4d353eef7064b100509197cc0f85d4cee084088db7a29c5bad2")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Easily include Permutive SDK in your Podfile:
 
 ```
 target 'Your Target' do
-    platform :tvos, '12.0'
-    pod 'Permutive_tvOS', '~> 2.6.1'
+    platform :tvos, '13.0'
+    pod 'Permutive_tvOS', '~> 3.0.0'
 end
 ```


### PR DESCRIPTION
- Add async API for cohorts and activations that awaits pending work (New)
- Bump min supported iOS and tvOS versions to 13 (Update)