### PR TITLE
Release v3.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name:"Permutive_tvOS",
-		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v3.0.0.zip",
-		checksum:"460ce792f6c3b4d353eef7064b100509197cc0f85d4cee084088db7a29c5bad2")
+		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v3.0.1.zip",
+		checksum:"a08d8f18e4fc5cf569eb1db186cc6c7ab7b99b069fe058635a73696cb245f9b0")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Easily include Permutive SDK in your Podfile:
 ```
 target 'Your Target' do
     platform :tvos, '13.0'
-    pod 'Permutive_tvOS', '~> 3.0.0'
+    pod 'Permutive_tvOS', '~> 3.0.1'
 end
 ```


### PR DESCRIPTION
- Fix VideoCompletion schema rejections by omitting empty cohort/segment aggregation keys from MediaTracker completion events (Fixed)
- Fix start() reporting success to concurrent callers before the SDK is active (Fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)