### PR TITLE
Release v3.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name:"Permutive_tvOS",
-		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v3.0.1.zip",
-		checksum:"a08d8f18e4fc5cf569eb1db186cc6c7ab7b99b069fe058635a73696cb245f9b0")
+		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_tvOS-v3.0.2.zip",
+		checksum:"f3c00156b79ed94faf7035e0ef01f0f4f629a6547e0bc87c25db6a8df70386b4")
     ]
 )


### PR DESCRIPTION
- Stop re-decoding the stored query state on every UserState write; the user-state entity graph now stays realized between writes (Fixed)
- Coalesce query-state persists behind a cooldown, with an immediate flush when the app moves to the background, bounding the serialization spikes that crashed sessions on low-memory devices (Fixed)